### PR TITLE
GRA-116: Slack při selhání parcelChange (mimo CZ)

### DIFF
--- a/src/ParcelObserver.php
+++ b/src/ParcelObserver.php
@@ -3,6 +3,8 @@
 namespace Ondrejsanetrnik\Parcelable;
 
 use App\Enums\EventName;
+use App\Models\User;
+use App\Services\SlackApi;
 use Illuminate\Support\Facades\Log;
 
 class ParcelObserver
@@ -32,7 +34,27 @@ class ParcelObserver
             try {
                 $parcel->parcelable?->fire('updated', 'parcelChange');
             } catch (\Throwable $e) {
-                Log::warning('Parcelable failed to fire parcelChange for ' . $parcel->parcelable->model_name_identifier . ' : ' . $e->getMessage() . ' ' . $e->getTraceAsString());
+                $identifier = $parcel->parcelable?->model_name_identifier ?? '?';
+                Log::warning('Parcelable failed to fire parcelChange for ' . $identifier . ' : ' . $e->getMessage() . ' ' . $e->getTraceAsString());
+
+                $country = $parcel->parcelable?->country ?? null;
+                if ($country !== 'CZ') {
+                    try {
+                        $slackId = User::find(1)?->slack_id;
+                        if ($slackId) {
+                            SlackApi::sendMessage(
+                                $slackId,
+                                "⚠️ Parcelable parcelChange selhalo: {$identifier}"
+                                    . ($country !== null ? " (země: {$country})" : '')
+                                    . "\n" . $e->getMessage()
+                            );
+                        }
+                    } catch (\Throwable $slackException) {
+                        Log::warning('Failed to send parcelChange Slack notification', [
+                            'error' => $slackException->getMessage(),
+                        ]);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Slack DM uživateli 1 (Ondra) při výjimce z `fire('updated', 'parcelChange')`, pokud `country !== 'CZ'`. Selhání Slacku se jen zaloguje.

Použito v gramodesky přes submodule (viz PR gramodesky#655).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new external Slack DM side-effect on exception paths in `ParcelObserver::updated`, which could impact error-handling behavior and introduce notification noise if failures spike.
> 
> **Overview**
> When `fire('updated', 'parcelChange')` throws in `ParcelObserver::updated`, the log message now uses a null-safe `model_name_identifier` fallback instead of assuming `parcelable` is present.
> 
> For non-`CZ` parcels, the observer additionally attempts to DM user `1` on Slack (via `SlackApi::sendMessage`) with the identifier/country and exception message; failures to send the Slack notification are caught and only logged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142698f83eadba15510c5ea50484216f4440797d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->