### PR TITLE
DPD: 25-digit barcode and multi-candidate tracking extraction

### DIFF
--- a/src/Concerns/DpdParcelIdentifier.php
+++ b/src/Concerns/DpdParcelIdentifier.php
@@ -5,24 +5,59 @@ namespace Ondrejsanetrnik\Parcelable\Concerns;
 trait DpdParcelIdentifier
 {
     /**
-     * Extracts the tracking number from DPD barcode (IPPPPPPPTTTTTTTTTTTTTTSSSCCC, 28 digits)
-     * or returns a plain 14-digit tracking number as-is
+     * Normalizes raw scanner output (DPD label spec: Code 128 must not begin with "%" in data, but scanners often add it).
+     */
+    public static function normalizeDpdBarcodeString(string $barcode): string
+    {
+        return ltrim(rtrim($barcode, '°'), '%');
+    }
+
+    /**
+     * Distinct 14-digit parcel numbers to try when matching {@see Parcel} tracking in the database.
+     * DPD uses multiple numeric payload lengths on labels (see DPD Parcel Label Specification — Code 128).
+     *
+     * @return list<string>
+     */
+    public static function parcelTrackingSearchValues(string $barcode): array
+    {
+        $n = self::normalizeDpdBarcodeString($barcode);
+        $candidates = [];
+
+        # 28-digit (and 27): postcode (7) + tracking (14) + service + country [/ check]
+        if (preg_match('/^\d{27,28}$/', $n)) {
+            $candidates[] = substr($n, 7, 14);
+        }
+
+        # 25-digit: identification (1) + postcode (7) + tracking (14) + service (3)
+        if (preg_match('/^\d{25}$/', $n)) {
+            $candidates[] = substr($n, 8, 14);
+            # Fallback when some devices omit the leading identification digit from the numeric read
+            $candidates[] = substr($n, 7, 14);
+        }
+
+        return array_values(array_unique(array_filter($candidates)));
+    }
+
+    /**
+     * Extracts the tracking number from DPD barcode (numeric label payload), or returns plain input if unknown.
      */
     public static function trackingNumberFromBarcode(string $barcode): string
     {
-        # DPD barcode format: 27 or 28 digits (I+postcode+tracking+service+country)
-        # Some scanners wrap values with "%" prefix or "°" suffix.
-        $normalizedBarcode = ltrim(rtrim($barcode, '°'), '%');
+        $candidates = self::parcelTrackingSearchValues($barcode);
 
-        if (preg_match('/^\d{27,28}$/', $normalizedBarcode)) return substr($normalizedBarcode, 7, 14);
+        if ($candidates !== []) {
+            return $candidates[0];
+        }
 
         return $barcode;
     }
 
     public static function isBarcode(?string $barcode = null): bool
     {
-        if (!$barcode) return false;
+        if (!$barcode) {
+            return false;
+        }
 
-        return boolval(self::trackingNumberFromBarcode($barcode) !== $barcode);
+        return self::parcelTrackingSearchValues($barcode) !== [];
     }
 }

--- a/src/ParcelObserver.php
+++ b/src/ParcelObserver.php
@@ -4,7 +4,6 @@ namespace Ondrejsanetrnik\Parcelable;
 
 use App\Enums\EventName;
 use App\Models\User;
-use App\Services\SlackApi;
 use Illuminate\Support\Facades\Log;
 
 class ParcelObserver
@@ -40,15 +39,11 @@ class ParcelObserver
                 $country = $parcel->parcelable?->country ?? null;
                 if ($country !== 'CZ') {
                     try {
-                        $slackId = User::find(1)?->slack_id;
-                        if ($slackId) {
-                            SlackApi::sendMessage(
-                                $slackId,
-                                "⚠️ Parcelable parcelChange selhalo: {$identifier}"
-                                    . ($country !== null ? " (země: {$country})" : '')
-                                    . "\n" . $e->getMessage()
-                            );
-                        }
+                        User::find(1)?->sendSlackMessage(
+                            "⚠️ Parcelable parcelChange selhalo: {$identifier}"
+                                . ($country !== null ? " (země: {$country})" : '')
+                                . "\n" . $e->getMessage()
+                        );
                     } catch (\Throwable $slackException) {
                         Log::warning('Failed to send parcelChange Slack notification', [
                             'error' => $slackException->getMessage(),


### PR DESCRIPTION
## Summary
- Add `normalizeDpdBarcodeString`, `parcelTrackingSearchValues`, refactor `trackingNumberFromBarcode` / `isBarcode` for 25-, 27-, and 28-digit numeric label reads.

## Test plan
- [ ] Consumer apps (gramodesky) resolve DPD scans with 25-digit payloads and `whereIn` candidates.

Made with [Cursor](https://cursor.com)