### PR TITLE
GRA-1473: Alza DPD shipping fixes

### DIFF
--- a/src/CarrierClassResolver.php
+++ b/src/CarrierClassResolver.php
@@ -16,7 +16,11 @@ final class CarrierClassResolver
             return BalikovnaAukro::class;
         }
 
-        if ($carrierName === 'DPD' && ($context?->baselinker_id ?? null)) {
+        if (
+            $carrierName === 'DPD'
+            && ($context?->baselinker_id ?? null)
+            && ($context?->source ?? null) !== 'alza'
+        ) {
             return DpdAllegro::class;
         }
 

--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -194,7 +194,8 @@ class Dpd
             $services['pickupPoint'] = $pudo;
         }
 
-        if (config('parcelable.DPD_NOTIFICATION', false)) {
+        # GeoAPI rejects PickupPoint without Notification (InvalidServiceCombination).
+        if ($pudo !== '' || config('parcelable.DPD_NOTIFICATION', false)) {
             $services['notification'] = true;
         }
 

--- a/src/ParcelObserver.php
+++ b/src/ParcelObserver.php
@@ -4,7 +4,6 @@ namespace Ondrejsanetrnik\Parcelable;
 
 use App\Enums\EventName;
 use App\Models\User;
-use App\Services\SlackApi;
 use Illuminate\Support\Facades\Log;
 
 class ParcelObserver
@@ -40,15 +39,11 @@ class ParcelObserver
                 $country = $parcel->parcelable?->country ?? null;
                 if ($country !== 'CZ') {
                     try {
-                        $slackId = User::find(1)?->slack_id;
-                        if ($slackId) {
-                            SlackApi::sendMessage(
-                                $slackId,
-                                "⚠️ Parcelable parcelChange selhalo: {$identifier}"
-                                    . ($country !== null ? " (země: {$country})" : '')
-                                    . "\n" . $e->getMessage()
-                            );
-                        }
+                        User::find(1)?->sendSlackMessage(
+                            "⚠️ Parcelable parcelChange selhalo: {$identifier}"
+                                . ($country !== null ? " (země: {$country})" : '')
+                                . "\n" . $e->getMessage()
+                        );
                     } catch (\Throwable $slackException) {
                         Log::warning('Failed to send parcelChange Slack notification', [
                             'error' => $slackException->getMessage(),

--- a/src/calls/UpdateBaselinkerParcelStatuses.php
+++ b/src/calls/UpdateBaselinkerParcelStatuses.php
@@ -21,15 +21,25 @@ class UpdateBaselinkerParcelStatuses
             ->whereIn('status', Parcel::ON_THE_WAY_STATUSES)
             ->chunk(100, function ($parcels) {
                 sleep(3);
+                $packageIds = $parcels
+                    ->pluck('external_id')
+                    ->map(static fn($externalId) => is_numeric($externalId) ? (int)$externalId : null)
+                    ->filter(static fn($packageId) => $packageId !== null && $packageId > 0)
+                    ->values()
+                    ->all();
 
-                $response = Api::baselinker()->courierShipments()->getCourierPackagesStatusHistory($parcels->pluck('external_id')->toArray());
+                if ($packageIds === []) {
+                    return;
+                }
+
+                $response = Api::baselinker()->courierShipments()->getCourierPackagesStatusHistory($packageIds);
 
                 if ($response->getParameter('status') === 'SUCCESS') {
-                    $statuses = $response->getParameter('packages_history');
+                    $packagesHistory = $response->getParameter('packages_history');
                     foreach ($parcels as $parcel) {
-                        $statuses = $statuses[$parcel->external_id] ?? null;
-                        if ($statuses) {
-                            $status = AllegroOne::STATUSES[array_pop($statuses)['tracking_status']] ?? 'V přepravě';
+                        $parcelHistory = $packagesHistory[$parcel->external_id] ?? null;
+                        if ($parcelHistory) {
+                            $status = AllegroOne::STATUSES[array_pop($parcelHistory)['tracking_status']] ?? 'V přepravě';
                             $parcel->update([
                                 'status'     => $status,
                                 'updated_at' => now(),


### PR DESCRIPTION
## Summary
- Alza orders (`source = alza`) with Baselinker ID use **DPD GeoAPI** (`Dpd`), not `DpdAllegro`.
- DPD shipment payload enables **notification** when a pickup point (PUDO) is set — required by GeoAPI (`InvalidServiceCombination` otherwise).
- Baselinker parcel status sync sends only numeric package IDs and fixes per-parcel history lookup (variable shadowing).

## Test plan
- [ ] Create parcel for an Alza order with `baselinker_id` — carrier class should be `Dpd`, API call should succeed
- [ ] Create DPD parcel with pickup point — no `InvalidServiceCombination` from GeoAPI
- [ ] Run / verify `UpdateBaselinkerParcelStatuses` for parcels with numeric `external_id`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes carrier selection and DPD GeoAPI request parameters, which can affect how shipments are created and validated by external APIs. Also adjusts Baselinker status polling inputs/lookup, so incorrect IDs could silently skip updates if assumptions about `external_id` differ.
> 
> **Overview**
> Fixes DPD handling for Alza-origin orders by preventing Baselinker-backed DPD parcels with `source = alza` from resolving to `DpdAllegro`, falling back to the standard DPD carrier class instead.
> 
> Updates DPD GeoAPI shipment payload generation to always enable `notification` when a `pickupPoint` (PUDO) is set to avoid `InvalidServiceCombination` errors.
> 
> Hardens `UpdateBaselinkerParcelStatuses` by sending only valid numeric `external_id` package IDs to Baselinker and correcting the per-parcel history lookup to avoid variable shadowing/mismatched history reads.
> 
> Separately, switches parcelChange Slack alerting to use `User::sendSlackMessage()` instead of calling `SlackApi` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209b2edfcc59fb23d46c2b4235e71570558a204c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->