### PR TITLE
GRA-1536: DPD GeoAPI účty podle eshop (Alza Trade)

### DIFF
--- a/config/parcelable.php
+++ b/config/parcelable.php
@@ -32,13 +32,11 @@ return [
     'DPD_USE_TEST_ENV'     => env('DPD_USE_TEST_ENV', false),
     'DPD_GEOAPI_BASE'      => env('DPD_GEOAPI_BASE', 'https://geoapi.dpd.cz/v1'),
     'DPD_GEOAPI_BASE_TEST' => env('DPD_GEOAPI_BASE_TEST', 'https://geoapi-test.dpd.cz/v1'),
-    'DPD_API_KEY'          => env('DPD_API_KEY'),
-    'DPD_API_KEY_TEST'     => env('DPD_API_KEY_TEST'),
-    'DPD_CUSTOMER_ID'      => env('DPD_CUSTOMER_ID'),
-    'DPD_SENDER_IT4EM_ID'  => env('DPD_SENDER_IT4EM_ID'),
     'DPD_LABEL_PAGE_SIZE'  => env('DPD_LABEL_PAGE_SIZE', 'A6'),
     'DPD_LABELS_PER_PAGE'  => env('DPD_LABELS_PER_PAGE', 1),
     'DPD_NOTIFICATION'     => env('DPD_NOTIFICATION', false),
+
+    'DPD_ACCOUNTS' => [],
 
     'GLS_PRICE_LIST' => [
         0 => [

--- a/src/CarrierClassResolver.php
+++ b/src/CarrierClassResolver.php
@@ -33,7 +33,7 @@ final class CarrierClassResolver
     {
         $delivery = (string)($context->delivery ?? '');
 
-        return ($context->country ?? '') === 'CZ'
+        return strtoupper(trim((string)($context->country ?? ''))) === 'CZ'
             && in_array($delivery, ['DPD', 'DPD Pickup'], true)
             && strcasecmp((string)($context->source ?? ''), 'allegro') !== 0
             && $delivery !== 'Allegro One';

--- a/src/CarrierClassResolver.php
+++ b/src/CarrierClassResolver.php
@@ -16,14 +16,26 @@ final class CarrierClassResolver
             return BalikovnaAukro::class;
         }
 
-        if (
-            $carrierName === 'DPD'
-            && ($context?->baselinker_id ?? null)
-            && ($context?->source ?? null) !== 'alza'
-        ) {
-            return DpdAllegro::class;
+        # Baselinker + DPD: vlastní GeoAPI (CZ) vs kurýr Allegro; Alza vždy {@see Dpd} přes výchozí mapování.
+        if ($carrierName === 'DPD' && ($context?->baselinker_id ?? null) && !self::isAlzaSource($context)) {
+            return self::usesOwnCzDpdContract($context) ? Dpd::class : DpdAllegro::class;
         }
 
         return Parcel::CARRIER_CLASS[$carrierName];
+    }
+
+    private static function isAlzaSource(?object $context): bool
+    {
+        return strcasecmp((string)($context?->source ?? ''), 'alza') === 0;
+    }
+
+    private static function usesOwnCzDpdContract(?object $context): bool
+    {
+        $delivery = (string)($context->delivery ?? '');
+
+        return ($context->country ?? '') === 'CZ'
+            && in_array($delivery, ['DPD', 'DPD Pickup'], true)
+            && strcasecmp((string)($context->source ?? ''), 'allegro') !== 0
+            && $delivery !== 'Allegro One';
     }
 }

--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -44,12 +44,14 @@ class Dpd
         $type = $type ?: $entity->default_parcel_type;
         if ($type === 'claim') return $coreResponse->fail('Reklamační zásilka DPD GeoAPI zatím není podporována.');
 
-        $customerId = config('parcelable.DPD_CUSTOMER_ID');
-        if (!$customerId) return $coreResponse->fail('Chybí konfigurace DPD_CUSTOMER_ID (viz GET /me v GeoAPI).');
+        $account = self::accountFor($entity);
+        if (!$account['customer_id']) {
+            return $coreResponse->fail('Chybí DPD účet pro eshop ' . ($entity->eshop ?? '?') . ' (config parcelable.DPD_ACCOUNTS).');
+        }
 
         $payload = [self::buildShipmentPayload($entity)];
 
-        $response = self::http()->post(self::baseUrl() . '/shipments', $payload);
+        $response = self::http($account)->post(self::baseUrl() . '/shipments', $payload);
 
         if ($response->failed()) {
             return $coreResponse->fail(self::formatHttpError('Vytvoření zásilky DPD', $response));
@@ -69,7 +71,7 @@ class Dpd
                 return $coreResponse->fail('DPD nevrátilo číslo zásilky (parcelNumbers.main).');
             }
 
-            $labelResponse = self::http()->withHeaders([
+            $labelResponse = self::http($account)->withHeaders([
                 'Accept' => 'application/pdf',
             ])->post(self::baseUrl() . '/parcels/labels', [
                 'printType'       => 'PDF',
@@ -102,11 +104,9 @@ class Dpd
         return $coreResponse->success($protoParcels);
     }
 
-    /**
-     * @return array<string, mixed>
-     */
     private static function buildShipmentPayload(Entity $entity): array
     {
+        $account = self::accountFor($entity);
         $parcelCount = max(1, (int)($entity->parcel_count ?: 1));
         $weightGrams = max(1, (int)round($entity->weight * 1000));
         $weightPerParcel = (int)max(1, round($weightGrams / $parcelCount));
@@ -140,13 +140,13 @@ class Dpd
         }
 
         $payload = [
-            'customer'     => ['id' => (int)config('parcelable.DPD_CUSTOMER_ID')],
+            'customer'     => ['id' => (int)$account['customer_id']],
             'shipmentType' => 'Standard',
             'references'   => [
                 'ref1' => (string)$entity->id,
             ],
             'sender' => [
-                'it4emId' => (int)config('parcelable.DPD_SENDER_IT4EM_ID'),
+                'it4emId' => $account['sender_it4em_id'],
             ],
             'receiver' => [
                 'info' => [
@@ -189,7 +189,9 @@ class Dpd
             ];
         }
 
-        $pudo = trim((string)($entity->packeta ?? ''));
+        # pickupPoint = výdejní místo (DPD služba 101). Pro doručení na adresu (327) nesmí být vyplněno.
+        $isDpdPickup = ($entity->delivery ?? '') === 'DPD Pickup';
+        $pudo = $isDpdPickup ? trim((string)($entity->packeta ?? '')) : '';
         if ($pudo !== '') {
             $services['pickupPoint'] = $pudo;
         }
@@ -216,13 +218,13 @@ class Dpd
         return strlen($c) === 2 ? $c : 'CZ';
     }
 
-    public static function getParcelStatus(int|string $parcelNumber): CoreResponse
+    public static function getParcelStatus(int|string $parcelNumber, Entity $entity): CoreResponse
     {
         $response = new CoreResponse();
 
         $parcelNumber = is_string($parcelNumber) ? preg_replace('/\s+/', '', $parcelNumber) : (string)$parcelNumber;
 
-        $http = self::http()->get(self::baseUrl() . '/parcels/' . rawurlencode($parcelNumber) . '/tracking');
+        $http = self::http(self::accountFor($entity))->get(self::baseUrl() . '/parcels/' . rawurlencode($parcelNumber) . '/tracking');
 
         if ($http->failed()) {
             return $response->fail(self::formatHttpError('Stav zásilky DPD', $http));
@@ -263,24 +265,30 @@ class Dpd
         return $response->success($statusObject);
     }
 
+    /**
+     * @return array{api_key: string, customer_id: string, sender_it4em_id: int}
+     */
+    private static function accountFor(Entity $entity): array
+    {
+        $raw = config('parcelable.DPD_ACCOUNTS')[(string)$entity->eshop] ?? [];
+        $test = (bool)config('parcelable.DPD_USE_TEST_ENV');
+
+        return [
+            'api_key'         => (string)($test ? ($raw['api_key_test'] ?? '') : ($raw['api_key'] ?? '')),
+            'customer_id'     => (string)($raw['customer_id'] ?? ''),
+            'sender_it4em_id' => (int)($raw['sender_it4em_id'] ?? 0),
+        ];
+    }
+
     private static function baseUrl(): string
     {
         return rtrim(config('parcelable.DPD_USE_TEST_ENV') ? config('parcelable.DPD_GEOAPI_BASE_TEST') : config('parcelable.DPD_GEOAPI_BASE'), '/');
     }
 
-    private static function apiKey(): string
-    {
-        if (config('parcelable.DPD_USE_TEST_ENV')) {
-            return (string)config('parcelable.DPD_API_KEY_TEST');
-        }
-
-        return (string)config('parcelable.DPD_API_KEY');
-    }
-
-    private static function http(): \Illuminate\Http\Client\PendingRequest
+    private static function http(array $account): \Illuminate\Http\Client\PendingRequest
     {
         return Http::withHeaders([
-            'x-api-key'    => self::apiKey(),
+            'x-api-key'    => $account['api_key'],
             'Content-Type' => 'application/json',
             'Accept'       => 'application/json',
         ])->timeout(120);

--- a/src/Parcel.php
+++ b/src/Parcel.php
@@ -175,7 +175,7 @@ class Parcel extends Entity
      */
     public function updateStatus(): CoreResponse
     {
-        $response = $this->carrier === 'DPD'
+        $response = $this->carrierClass === Dpd::class
             ? Dpd::getParcelStatus($this->tracking_number, $this->parcelable)
             : $this->carrierClass::getParcelStatus($this->tracking_number);
 

--- a/src/Parcel.php
+++ b/src/Parcel.php
@@ -175,7 +175,9 @@ class Parcel extends Entity
      */
     public function updateStatus(): CoreResponse
     {
-        $response = $this->carrierClass::getParcelStatus($this->tracking_number);
+        $response = $this->carrier === 'DPD'
+            ? Dpd::getParcelStatus($this->tracking_number, $this->parcelable)
+            : $this->carrierClass::getParcelStatus($this->tracking_number);
 
         # Persist if successful
         if ($response->success && $response->data) $this->update([


### PR DESCRIPTION
## Summary
- DPD GeoAPI credentials resolved from `DPD_ACCOUNTS` by `entity->eshop` (same pattern as GLS)
- `Dpd::accountFor()` replaces flat config keys; tracking uses order entity for correct API key
- `CarrierClassResolver` simplified for Baselinker DPD vs Allegro kurýr; Alza orders skip that branch

## Test plan
- [ ] Merge after/deploy with matching gramodesky `config/parcelable.php` (`DPD_ACCOUNTS` + `DPD_ALZA_*` env)
- [ ] Create parcel on CZ Alza order (source `alza`, DPD) — label uses Alza Trade account
- [ ] Create parcel on non-Alza CZ DPD order — uses Gramodesky s.r.o. account
- [ ] Parcel status update works for both account types

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shipment creation and tracking now depend on correct DPD_ACCOUNTS deployment per eshop; misconfiguration blocks labels or uses wrong contract, but scope is limited to DPD integration.
> 
> **Overview**
> **DPD GeoAPI** přestává používat globální `DPD_API_KEY` / `DPD_CUSTOMER_ID` / `DPD_SENDER_IT4EM_ID` a bere přihlašovací údaje z **`parcelable.DPD_ACCOUNTS`** podle **`entity->eshop`** (stejný princip jako u GLS klientů). Vytváření zásilek, štítků i trackingu volá `Dpd::accountFor()` a HTTP klient s odpovídajícím `x-api-key`.
> 
> **CarrierClassResolver** u Baselinker + DPD rozlišuje vlastní českou smlouvu (`Dpd`) vs kurýra Allegro (`DpdAllegro`) podle země, doručení a zdroje; objednávky se zdrojem **Alza** tuto větev přeskočí a jedou přes výchozí mapování na `Dpd` (účet podle eshopu).
> 
> **DPD Pickup**: `pickupPoint` se posílá jen u doručení `DPD Pickup`, ne u doručení na adresu. **`Parcel::updateStatus`** předává u `Dpd` entitu objednávky, aby tracking používal stejný účet jako při vytvoření zásilky.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf3743795debeeb831bb551e8412b613ff5deb82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->