### PR TITLE
Fix DPD GeoAPI customer ident for Alza (DSW vs id)

### DIFF
--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -17,6 +17,9 @@ class Dpd
 {
     use Concerns\DpdParcelIdentifier;
 
+    # GeoAPI internal CustomerID is short; DPD customer number (DSW) is much longer.
+    private const CUSTOMER_INTERNAL_ID_MAX_LENGTH = 6;
+
     public const STATUS_MAP = [
         'Parcel is delivered to recipient'              => 'Doručena',
         'Delivered'                                     => 'Doručena',
@@ -140,7 +143,7 @@ class Dpd
         }
 
         $payload = [
-            'customer'     => ['id' => (int)$account['customer_id']],
+            'customer'     => self::buildCustomerIdent($account),
             'shipmentType' => 'Standard',
             'references'   => [
                 'ref1' => (string)$entity->id,
@@ -263,6 +266,26 @@ class Dpd
         ];
 
         return $response->success($statusObject);
+    }
+
+    /**
+     * GeoAPI CustomerIdent: either internal CustomerID (`id`) or DPD customer number (`dsw`).
+     *
+     * @param array{customer_id: string} $account
+     * @return array{dsw: string}|array{id: int}
+     */
+    private static function buildCustomerIdent(array $account): array
+    {
+        $customerId = trim((string)($account['customer_id'] ?? ''));
+        if ($customerId === '') {
+            return [];
+        }
+
+        if (strlen($customerId) > self::CUSTOMER_INTERNAL_ID_MAX_LENGTH) {
+            return ['dsw' => $customerId];
+        }
+
+        return ['id' => (int)$customerId];
     }
 
     /**


### PR DESCRIPTION
## Summary
- Při vytváření zásilky DPD GeoAPI se typ zákazníka určí podle délky `customer_id` z configu: více než 6 znaků → `dsw` (klientské číslo DPD, Alza Trade), 6 a méně → `id` (interní CustomerID).
- Opravuje chybu `ShipmentCustomerNotFound` / HTTP 404 pro účet Alza (`10627082440`).

## Test plan
- [ ] Vytvořit DPD zásilku u objednávky se zdrojem Alza (eshop `GRAMODESKY.CZ`) — bez chyby 404
- [ ] Ověřit, že standardní účet (`GRAMODESKY.CZ s.r.o.`) s krátkým `DPD_CUSTOMER_ID` stále funguje

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every DPD shipment identifies the customer in GeoAPI; wrong length threshold could break short-ID accounts or still fail for edge-case IDs, but scope is limited to one helper and existing short IDs are unchanged.
> 
> **Overview**
> DPD GeoAPI shipment payloads no longer always send `customer` as `{ id: <int> }`. **`buildCustomerIdent`** chooses the field GeoAPI expects: **`dsw`** when configured `customer_id` is longer than 6 characters (DPD client number, e.g. Alza), otherwise **`id`** as an integer (short internal CustomerID).
> 
> This fixes **`ShipmentCustomerNotFound` / HTTP 404** for accounts whose config stores a long DSW instead of a short internal ID. Existing shops with short `customer_id` values keep the previous behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc41bca756cdfc4071654395dc76c58189d481cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->