### PR TITLE
Fix DPD status updates when parcelable is missing

### DIFF
--- a/src/Parcel.php
+++ b/src/Parcel.php
@@ -175,9 +175,17 @@ class Parcel extends Entity
      */
     public function updateStatus(): CoreResponse
     {
-        $response = $this->carrierClass === Dpd::class
-            ? Dpd::getParcelStatus($this->tracking_number, $this->parcelable)
-            : $this->carrierClass::getParcelStatus($this->tracking_number);
+        if ($this->carrierClass === Dpd::class) {
+            if (!$this->parcelable instanceof Entity) {
+                $response = new CoreResponse();
+
+                return $response->fail('DPD status: chybí parcelable (objednávka/zásilka).');
+            }
+
+            $response = Dpd::getParcelStatus($this->tracking_number, $this->parcelable);
+        } else {
+            $response = $this->carrierClass::getParcelStatus($this->tracking_number);
+        }
 
         # Persist if successful
         if ($response->success && $response->data) $this->update([

--- a/src/ParcelCheckup.php
+++ b/src/ParcelCheckup.php
@@ -13,6 +13,7 @@ class ParcelCheckup
     {
         Parcel::query()
             ->where('carrier', '!=', 'Allegro One') # Allegro One is updated in batch through separate call
+            ->where(fn($q) => $q->where('carrier', '!=', 'DPD')->orWhereNotNull('parcelable_id'))
             ->whereIn('status', Parcel::ON_THE_WAY_STATUSES)
             ->when(rand(1, 100) <= 99, fn($q) => $q->where('updated_at', '>', now()->subMonth()))
             ->inRandomOrder()


### PR DESCRIPTION
## Summary
- `Parcel::updateStatus()` — u DPD nejdřív ověří, že existuje `parcelable` (objednávka/zásilka); jinak vrátí srozumitelnou chybu místo pádu.
- `ParcelCheckup` — v dávkovém refreshi stavů přeskočí DPD zásilky bez `parcelable_id` (u DPD je potřeba eshop pro výběr GeoAPI účtu).

## Test plan
- [ ] Spustit parcel checkup / `updateStatus` na DPD zásilce s navázanou objednávkou — stav se aktualizuje
- [ ] DPD zásilka bez `parcelable_id` se v checkupu nebere do fronty

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted guardrails around DPD status polling; no auth or payment changes, only skips or fails invalid DPD rows.
> 
> **Overview**
> **DPD tracking** now requires a linked `parcelable` (order/shipment) before calling the carrier API, because DPD status uses that entity to pick the correct GeoAPI account.
> 
> `Parcel::updateStatus()` returns a clear failure instead of erroring when DPD has no `parcelable`. **`ParcelCheckup`** excludes in-transit DPD rows without `parcelable_id` from the bulk refresh so they are not polled until linked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce0b98b428a92f63f02e54e649c6b7e8b534c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->