### PR TITLE
GRA-1536: Alza Trade DPD service mapping (327/337/101)

### DIFF
--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -238,29 +238,19 @@ class Dpd
 
     /**
      * GeoAPI service elements → IT4EM product on label (Alza Trade contract):
-     * 327 home prepaid, 329 home COD, 337 DPD box (pickupPoint), 101 Alza branch (pickupPoint when known).
+     * 327/329 home (notification, optional COD), 337 box (pickupPoint + notification), 101 supplier (empty services).
      *
      * @return array<string, mixed>|object
      */
     private static function buildServices(Entity $entity): array|object
     {
-        $services = [];
-
-        if ($entity->is_cod) {
-            $currency = $entity->national_currency ?: 'CZK';
-            $parcelCount = max(1, (int)($entity->parcel_count ?: 1));
-            $amountCents = (int)round((float)$entity->cod_for_parcel * $parcelCount * 100);
-            $services['cashOnDelivery'] = [
-                'amountCents' => $amountCents,
-                'currency'    => $currency,
-                'payment'     => 'Cash',
-            ];
+        if (CarrierClassResolver::isAlzaSource($entity)) {
+            return self::buildAlzaTradeServices($entity);
         }
 
-        $pudo = CarrierClassResolver::isAlzaSource($entity)
-            ? self::alzaTradePickupPoint($entity)
-            : self::defaultPickupPoint($entity);
+        $services = self::codService($entity);
 
+        $pudo = self::defaultPickupPoint($entity);
         if ($pudo !== '') {
             $services['pickupPoint'] = $pudo;
         }
@@ -274,36 +264,76 @@ class Dpd
     }
 
     /**
-     * Alza Trade: product from orders.carrier_id (Baselinker delivery_method), not from delivery label alone.
+     * Alza Trade: carrier_id from Baselinker delivery_method (see GET /shipping-services examples).
      */
-    private static function alzaTradePickupPoint(Entity $entity): string
+    private static function buildAlzaTradeServices(Entity $entity): array|object
     {
+        $services = self::codService($entity);
         $method = trim((string)($entity->carrier_id ?? ''));
 
-        return match ($method) {
-            self::ALZA_CARRIER_HOME     => '',
-            self::ALZA_CARRIER_BOX      => self::requirePickupPointId($entity, self::ALZA_CARRIER_BOX),
-            self::ALZA_CARRIER_SUPPLIER => trim((string)($entity->packeta ?? '')),
-            default                     => self::alzaTradePickupPointFallback($entity, $method),
-        };
+        if ($method === '' || !str_starts_with($method, 'DPD-')) {
+            $method = self::inferAlzaCarrierId($entity, $method);
+        }
+
+        if ($method === self::ALZA_CARRIER_SUPPLIER) {
+            # 101 — GeoAPI example uses empty services (no notification, no pickupPoint).
+            return $services === [] ? (object)[] : $services;
+        }
+
+        if ($method === self::ALZA_CARRIER_BOX || str_contains($method, 'ALZABOX') || str_contains($method, 'DPDALZABOX')) {
+            $pudo = self::requirePickupPointId($entity, $method ?: self::ALZA_CARRIER_BOX);
+            if ($pudo !== '') {
+                $services['pickupPoint'] = $pudo;
+            }
+            $services['notification'] = true;
+
+            return $services;
+        }
+
+        # DPD-DPD (and fallback): 327/329 — notification only, never packeta on home delivery.
+        $services['notification'] = true;
+
+        return $services;
     }
 
-    private static function alzaTradePickupPointFallback(Entity $entity, string $method): string
+    private static function inferAlzaCarrierId(Entity $entity, string $method): string
     {
-        if ($method !== '' && !str_starts_with($method, 'DPD-')) {
-            return '';
+        if ($method !== '') {
+            return $method;
         }
 
-        if (str_contains($method, 'ALZABOX') || str_contains($method, 'DPDALZABOX')) {
-            return self::requirePickupPointId($entity, $method);
+        $packeta = trim((string)($entity->packeta ?? ''));
+        if ($packeta !== '' && str_starts_with(strtoupper($packeta), 'CZ')) {
+            return self::ALZA_CARRIER_BOX;
         }
 
-        if ($method === self::ALZA_CARRIER_SUPPLIER || str_contains($method, 'Supplier')) {
-            return trim((string)($entity->packeta ?? ''));
+        if ($packeta !== '' && str_starts_with(strtoupper($packeta), 'AL')) {
+            return self::ALZA_CARRIER_SUPPLIER;
         }
 
-        # DPD-DPD / missing carrier_id: home (327/329) — never send packeta (wrong 337/101).
-        return '';
+        return self::ALZA_CARRIER_HOME;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function codService(Entity $entity): array
+    {
+        if (!$entity->is_cod) {
+            return [];
+        }
+
+        $currency = $entity->national_currency ?: 'CZK';
+        $parcelCount = max(1, (int)($entity->parcel_count ?: 1));
+        $amountCents = (int)round((float)$entity->cod_for_parcel * $parcelCount * 100);
+
+        return [
+            'cashOnDelivery' => [
+                'amountCents' => $amountCents,
+                'currency'    => $currency,
+                'payment'     => 'Cash',
+            ],
+        ];
     }
 
     private static function defaultPickupPoint(Entity $entity): string

--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -23,6 +23,13 @@ class Dpd
     # GeoAPI references: up to 4 strings, max 35 chars each (shipment + parcel level).
     private const REFERENCE_MAX_LENGTH = 35;
 
+    # Baselinker Alza Trade delivery_method values (synced to orders.carrier_id).
+    private const ALZA_CARRIER_HOME = 'DPD-DPD';
+
+    private const ALZA_CARRIER_BOX = 'DPD-DPDALZABOX';
+
+    private const ALZA_CARRIER_SUPPLIER = 'DPD-Supplier';
+
     public const STATUS_MAP = [
         'Parcel is delivered to recipient'              => 'Doručena',
         'Delivered'                                     => 'Doručena',
@@ -230,6 +237,9 @@ class Dpd
     }
 
     /**
+     * GeoAPI service elements → IT4EM product on label (Alza Trade contract):
+     * 327 home prepaid, 329 home COD, 337 DPD box (pickupPoint), 101 Alza branch (pickupPoint when known).
+     *
      * @return array<string, mixed>|object
      */
     private static function buildServices(Entity $entity): array|object
@@ -247,9 +257,10 @@ class Dpd
             ];
         }
 
-        # pickupPoint = výdejní místo (DPD služba 101). Pro doručení na adresu (327) nesmí být vyplněno.
-        $isDpdPickup = ($entity->delivery ?? '') === 'DPD Pickup';
-        $pudo = $isDpdPickup ? trim((string)($entity->packeta ?? '')) : '';
+        $pudo = CarrierClassResolver::isAlzaSource($entity)
+            ? self::alzaTradePickupPoint($entity)
+            : self::defaultPickupPoint($entity);
+
         if ($pudo !== '') {
             $services['pickupPoint'] = $pudo;
         }
@@ -260,6 +271,62 @@ class Dpd
         }
 
         return $services === [] ? (object)[] : $services;
+    }
+
+    /**
+     * Alza Trade: product from orders.carrier_id (Baselinker delivery_method), not from delivery label alone.
+     */
+    private static function alzaTradePickupPoint(Entity $entity): string
+    {
+        $method = trim((string)($entity->carrier_id ?? ''));
+
+        return match ($method) {
+            self::ALZA_CARRIER_HOME     => '',
+            self::ALZA_CARRIER_BOX      => self::requirePickupPointId($entity, self::ALZA_CARRIER_BOX),
+            self::ALZA_CARRIER_SUPPLIER => trim((string)($entity->packeta ?? '')),
+            default                     => self::alzaTradePickupPointFallback($entity, $method),
+        };
+    }
+
+    private static function alzaTradePickupPointFallback(Entity $entity, string $method): string
+    {
+        if ($method !== '' && !str_starts_with($method, 'DPD-')) {
+            return '';
+        }
+
+        if (str_contains($method, 'ALZABOX') || str_contains($method, 'DPDALZABOX')) {
+            return self::requirePickupPointId($entity, $method);
+        }
+
+        if ($method === self::ALZA_CARRIER_SUPPLIER || str_contains($method, 'Supplier')) {
+            return trim((string)($entity->packeta ?? ''));
+        }
+
+        # DPD-DPD / missing carrier_id: home (327/329) — never send packeta (wrong 337/101).
+        return '';
+    }
+
+    private static function defaultPickupPoint(Entity $entity): string
+    {
+        if (($entity->delivery ?? '') !== 'DPD Pickup') {
+            return '';
+        }
+
+        return trim((string)($entity->packeta ?? ''));
+    }
+
+    private static function requirePickupPointId(Entity $entity, string $context): string
+    {
+        $pudo = trim((string)($entity->packeta ?? ''));
+        if ($pudo === '') {
+            Log::channel('separated')->warning('DPD Alza Trade: missing pickup point ID', [
+                'order_id'   => $entity->id,
+                'carrier_id' => $entity->carrier_id,
+                'context'    => $context,
+            ]);
+        }
+
+        return $pudo;
     }
 
     private static function normalizePhone(?string $phone): string

--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -62,7 +62,11 @@ class Dpd
             return $coreResponse->fail('Chybí DPD účet pro eshop ' . ($entity->eshop ?? '?') . ' (config parcelable.DPD_ACCOUNTS).');
         }
 
-        $payload = [self::buildShipmentPayload($entity)];
+        try {
+            $payload = [self::buildShipmentPayload($entity)];
+        } catch (\RuntimeException $e) {
+            return $coreResponse->fail($e->getMessage());
+        }
 
         $response = self::http($account)->post(self::baseUrl() . '/shipments', $payload);
 
@@ -349,11 +353,9 @@ class Dpd
     {
         $pudo = trim((string)($entity->packeta ?? ''));
         if ($pudo === '') {
-            Log::channel('separated')->warning('DPD Alza Trade: missing pickup point ID', [
-                'order_id'   => $entity->id,
-                'carrier_id' => $entity->carrier_id,
-                'context'    => $context,
-            ]);
+            throw new \RuntimeException(
+                'DPD Alza Trade box: chybí pickup point ID (packeta) pro objednávku ' . $entity->id . ' [' . $context . ']'
+            );
         }
 
         return $pudo;


### PR DESCRIPTION
## Summary
- Map Alza Trade DPD products from `orders.carrier_id` (Baselinker `delivery_method`): `DPD-DPD` → 327/329, `DPD-DPDALZABOX` → 337 with `pickupPoint`, `DPD-Supplier` → 101 with empty GeoAPI `services` (no notification)
- Split `buildAlzaTradeServices()` from generic DPD logic; extract `codService()`
- Legacy fallback when `carrier_id` missing (infer from `packeta` prefix)

## Test plan
- [ ] Alza order `DPD-DPD` prepaid → label shows **327**, REF = `external_id`
- [ ] Alza order `DPD-DPDALZABOX` with `packeta` (e.g. CZ22377) → label **337**
- [ ] Alza order `DPD-Supplier` → label **101** (not 327); requires empty services, not `DPD_NOTIFICATION` alone
- [ ] Non-Alza DPD unchanged


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shipment payload services for Alza-sourced orders and can block label creation if box pickup ID is missing; incorrect mapping would produce wrong DPD products on labels.
> 
> **Overview**
> Adds **Alza Trade**–specific DPD GeoAPI `services` mapping in `Dpd::buildServices`, driven by Baselinker `delivery_method` values stored on `orders.carrier_id` (`DPD-DPD`, `DPD-DPDALZABOX`, `DPD-Supplier`).
> 
> For Alza orders, `buildAlzaTradeServices` maps those carriers to the correct IT4EM products: home delivery gets **notification only** (327/329, no `pickupPoint` on address delivery), box delivery requires `packeta` as `pickupPoint` plus notification (337), and supplier uses **empty** services aside from optional COD (101). Missing box `packeta` now fails shipment creation with a clear `RuntimeException` caught in `createFrom`. COD logic is shared via new `codService()`; non-Alza DPD behavior stays on the existing pickup + `DPD_NOTIFICATION` path.
> 
> When `carrier_id` is missing or not a `DPD-*` value, `inferAlzaCarrierId` falls back from `packeta` prefixes (`CZ` → box, `AL` → supplier, else home).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795069ccf2be76f898e7704974bf9eb4b0119cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->