### PR TITLE
DPD full barcode for Baselinker/Alza package sync

### DIFF
--- a/src/Concerns/DpdParcelIdentifier.php
+++ b/src/Concerns/DpdParcelIdentifier.php
@@ -4,11 +4,6 @@ namespace Ondrejsanetrnik\Parcelable\Concerns;
 
 trait DpdParcelIdentifier
 {
-    # DPD numeric destination country on barcode.
-    private const BARCODE_COUNTRY_CZ = '203';
-
-    private const BARCODE_COUNTRY_SK = '703';
-
     /**
      * Extracts the tracking number from DPD barcode (IPPPPPPPTTTTTTTTTTTTTTSSSCCC, 28 digits)
      * or returns a plain 14-digit tracking number as-is
@@ -35,46 +30,4 @@ trait DpdParcelIdentifier
         return self::trackingNumberFromBarcode($barcode) !== $barcode;
     }
 
-    /**
-     * Builds DPD Code 128 payload for Baselinker: % + PSČ(7) + tracking(14) + služba(3) + země(3).
-     * GeoAPI returns only parcelNumbers.main (14 digits); full form matches the physical label barcode.
-     */
-    public static function fullBarcodeForBaselinker(object $entity, string $trackingNumber): string
-    {
-        $normalized = ltrim(rtrim($trackingNumber, '°'), '%');
-
-        if (preg_match('/^\d{27}$/', $normalized)) {
-            return '%' . $normalized;
-        }
-
-        $main = preg_replace('/\D/', '', self::trackingNumberFromBarcode($trackingNumber));
-        if (strlen($main) !== 14) {
-            return $trackingNumber;
-        }
-
-        $postcode = self::postcodeFieldForBarcode($entity->postal_code ?? null);
-        $service = str_pad((string)self::it4emServiceCodeForBaselinker($entity), 3, '0', STR_PAD_LEFT);
-        $country = self::destinationCountryCodeForBarcode($entity->country ?? 'CZ');
-
-        return '%' . $postcode . $main . $service . $country;
-    }
-
-    private static function postcodeFieldForBarcode(?string $postalCode): string
-    {
-        $digits = preg_replace('/\D/', '', (string)$postalCode);
-        if ($digits === '') {
-            $digits = '0';
-        }
-
-        return str_pad(substr($digits, -7), 7, '0', STR_PAD_LEFT);
-    }
-
-    private static function destinationCountryCodeForBarcode(?string $country): string
-    {
-        return match (strtoupper(trim((string)$country))) {
-            'CZ'    => self::BARCODE_COUNTRY_CZ,
-            'SK'    => self::BARCODE_COUNTRY_SK,
-            default => self::BARCODE_COUNTRY_CZ,
-        };
-    }
 }

--- a/src/Concerns/DpdParcelIdentifier.php
+++ b/src/Concerns/DpdParcelIdentifier.php
@@ -4,6 +4,11 @@ namespace Ondrejsanetrnik\Parcelable\Concerns;
 
 trait DpdParcelIdentifier
 {
+    # DPD numeric destination country on barcode.
+    private const BARCODE_COUNTRY_CZ = '203';
+
+    private const BARCODE_COUNTRY_SK = '703';
+
     /**
      * Extracts the tracking number from DPD barcode (IPPPPPPPTTTTTTTTTTTTTTSSSCCC, 28 digits)
      * or returns a plain 14-digit tracking number as-is
@@ -14,15 +19,62 @@ trait DpdParcelIdentifier
         # Some scanners wrap values with "%" prefix or "°" suffix.
         $normalizedBarcode = ltrim(rtrim($barcode, '°'), '%');
 
-        if (preg_match('/^\d{27,28}$/', $normalizedBarcode)) return substr($normalizedBarcode, 7, 14);
+        if (preg_match('/^\d{27,28}$/', $normalizedBarcode)) {
+            return substr($normalizedBarcode, 7, 14);
+        }
 
         return $barcode;
     }
 
     public static function isBarcode(?string $barcode = null): bool
     {
-        if (!$barcode) return false;
+        if (!$barcode) {
+            return false;
+        }
 
-        return boolval(self::trackingNumberFromBarcode($barcode) !== $barcode);
+        return self::trackingNumberFromBarcode($barcode) !== $barcode;
+    }
+
+    /**
+     * Builds DPD Code 128 payload for Baselinker: % + PSČ(7) + tracking(14) + služba(3) + země(3).
+     * GeoAPI returns only parcelNumbers.main (14 digits); full form matches the physical label barcode.
+     */
+    public static function fullBarcodeForBaselinker(object $entity, string $trackingNumber): string
+    {
+        $normalized = ltrim(rtrim($trackingNumber, '°'), '%');
+
+        if (preg_match('/^\d{27}$/', $normalized)) {
+            return '%' . $normalized;
+        }
+
+        $main = preg_replace('/\D/', '', self::trackingNumberFromBarcode($trackingNumber));
+        if (strlen($main) !== 14) {
+            return $trackingNumber;
+        }
+
+        $postcode = self::postcodeFieldForBarcode($entity->postal_code ?? null);
+        $service = str_pad((string)self::it4emServiceCodeForBaselinker($entity), 3, '0', STR_PAD_LEFT);
+        $country = self::destinationCountryCodeForBarcode($entity->country ?? 'CZ');
+
+        return '%' . $postcode . $main . $service . $country;
+    }
+
+    private static function postcodeFieldForBarcode(?string $postalCode): string
+    {
+        $digits = preg_replace('/\D/', '', (string)$postalCode);
+        if ($digits === '') {
+            $digits = '0';
+        }
+
+        return str_pad(substr($digits, -7), 7, '0', STR_PAD_LEFT);
+    }
+
+    private static function destinationCountryCodeForBarcode(?string $country): string
+    {
+        return match (strtoupper(trim((string)$country))) {
+            'CZ'    => self::BARCODE_COUNTRY_CZ,
+            'SK'    => self::BARCODE_COUNTRY_SK,
+            default => self::BARCODE_COUNTRY_CZ,
+        };
     }
 }

--- a/src/Concerns/DpdParcelIdentifier.php
+++ b/src/Concerns/DpdParcelIdentifier.php
@@ -14,8 +14,12 @@ trait DpdParcelIdentifier
         # Some scanners wrap values with "%" prefix or "°" suffix.
         $normalizedBarcode = ltrim(rtrim($barcode, '°'), '%');
 
-        if (preg_match('/^\d{27,28}$/', $normalizedBarcode)) {
+        if (preg_match('/^\d{27}$/', $normalizedBarcode)) {
             return substr($normalizedBarcode, 7, 14);
+        }
+
+        if (preg_match('/^\d{28}$/', $normalizedBarcode)) {
+            return substr($normalizedBarcode, 8, 14);
         }
 
         return $barcode;

--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -316,6 +316,10 @@ class Dpd
             return '%' . $normalized;
         }
 
+        if (preg_match('/^\d{28}$/', $normalized)) {
+            return '%' . substr($normalized, 1);
+        }
+
         $main = preg_replace('/\D/', '', self::trackingNumberFromBarcode($trackingNumber));
         if (strlen($main) !== 14) {
             return $trackingNumber;

--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -30,6 +30,15 @@ class Dpd
 
     private const ALZA_CARRIER_SUPPLIER = 'DPD-Supplier';
 
+    # IT4EM product codes embedded in the DPD label barcode (must match GeoAPI / printed label).
+    private const IT4EM_SERVICE_HOME = 327;
+
+    private const IT4EM_SERVICE_HOME_COD = 329;
+
+    private const IT4EM_SERVICE_BOX = 337;
+
+    private const IT4EM_SERVICE_SUPPLIER = 101;
+
     public const STATUS_MAP = [
         'Parcel is delivered to recipient'              => 'Doručena',
         'Delivered'                                     => 'Doručena',
@@ -270,14 +279,30 @@ class Dpd
     /**
      * Alza Trade: carrier_id from Baselinker delivery_method (see GET /shipping-services examples).
      */
+    /**
+     * IT4EM service digit triplet in the DPD barcode (Baselinker / Alza full package number).
+     */
+    public static function it4emServiceCodeForBaselinker(Entity $entity): int
+    {
+        if (CarrierClassResolver::isAlzaSource($entity)) {
+            return self::alzaIt4emServiceCode($entity);
+        }
+
+        if (($entity->delivery ?? '') === 'DPD Pickup' && trim((string)($entity->packeta ?? '')) !== '') {
+            return self::IT4EM_SERVICE_BOX;
+        }
+
+        if ($entity->is_cod) {
+            return self::IT4EM_SERVICE_HOME_COD;
+        }
+
+        return self::IT4EM_SERVICE_HOME;
+    }
+
     private static function buildAlzaTradeServices(Entity $entity): array|object
     {
         $services = self::codService($entity);
-        $method = trim((string)($entity->carrier_id ?? ''));
-
-        if ($method === '' || !str_starts_with($method, 'DPD-')) {
-            $method = self::inferAlzaCarrierId($entity, $method);
-        }
+        $method = self::resolvedAlzaCarrierMethod($entity);
 
         if ($method === self::ALZA_CARRIER_SUPPLIER) {
             # 101 — GeoAPI example uses empty services (no notification, no pickupPoint).
@@ -298,6 +323,36 @@ class Dpd
         $services['notification'] = true;
 
         return $services;
+    }
+
+    private static function resolvedAlzaCarrierMethod(Entity $entity): string
+    {
+        $method = trim((string)($entity->carrier_id ?? ''));
+
+        if ($method === '' || !str_starts_with($method, 'DPD-')) {
+            return self::inferAlzaCarrierId($entity, $method);
+        }
+
+        return $method;
+    }
+
+    private static function alzaIt4emServiceCode(Entity $entity): int
+    {
+        $method = self::resolvedAlzaCarrierMethod($entity);
+
+        if ($method === self::ALZA_CARRIER_SUPPLIER) {
+            return self::IT4EM_SERVICE_SUPPLIER;
+        }
+
+        if ($method === self::ALZA_CARRIER_BOX || str_contains($method, 'ALZABOX') || str_contains($method, 'DPDALZABOX')) {
+            return self::IT4EM_SERVICE_BOX;
+        }
+
+        if ($entity->is_cod) {
+            return self::IT4EM_SERVICE_HOME_COD;
+        }
+
+        return self::IT4EM_SERVICE_HOME;
     }
 
     private static function inferAlzaCarrierId(Entity $entity, string $method): string

--- a/src/Dpd.php
+++ b/src/Dpd.php
@@ -30,6 +30,11 @@ class Dpd
 
     private const ALZA_CARRIER_SUPPLIER = 'DPD-Supplier';
 
+    # DPD numeric destination country on barcode.
+    private const BARCODE_COUNTRY_CZ = '203';
+
+    private const BARCODE_COUNTRY_SK = '703';
+
     # IT4EM product codes embedded in the DPD label barcode (must match GeoAPI / printed label).
     private const IT4EM_SERVICE_HOME = 327;
 
@@ -297,6 +302,49 @@ class Dpd
         }
 
         return self::IT4EM_SERVICE_HOME;
+    }
+
+    /**
+     * Builds DPD Code 128 payload for Baselinker: % + PSČ(7) + tracking(14) + služba(3) + země(3).
+     * GeoAPI returns only parcelNumbers.main (14 digits); full form matches the physical label barcode.
+     */
+    public static function fullBarcodeForBaselinker(object $entity, string $trackingNumber): string
+    {
+        $normalized = ltrim(rtrim($trackingNumber, '°'), '%');
+
+        if (preg_match('/^\d{27}$/', $normalized)) {
+            return '%' . $normalized;
+        }
+
+        $main = preg_replace('/\D/', '', self::trackingNumberFromBarcode($trackingNumber));
+        if (strlen($main) !== 14) {
+            return $trackingNumber;
+        }
+
+        $postcode = self::postcodeFieldForBarcode($entity->postal_code ?? null);
+        $service = str_pad((string)self::it4emServiceCodeForBaselinker($entity), 3, '0', STR_PAD_LEFT);
+        $country = self::destinationCountryCodeForBarcode($entity->country ?? 'CZ');
+
+        return '%' . $postcode . $main . $service . $country;
+    }
+
+    private static function postcodeFieldForBarcode(?string $postalCode): string
+    {
+        $digits = preg_replace('/\D/', '', (string)$postalCode);
+        if ($digits === '') {
+            $digits = '0';
+        }
+
+        return str_pad(substr($digits, -7), 7, '0', STR_PAD_LEFT);
+    }
+
+    private static function destinationCountryCodeForBarcode(?string $country): string
+    {
+        return match (strtoupper(trim((string)$country))) {
+            'CZ'    => self::BARCODE_COUNTRY_CZ,
+            'SK'    => self::BARCODE_COUNTRY_SK,
+            default => self::BARCODE_COUNTRY_CZ,
+        };
     }
 
     private static function buildAlzaTradeServices(Entity $entity): array|object


### PR DESCRIPTION
## Summary
- Add `fullBarcodeForBaselinker()` to build the 27-digit DPD Code 128 payload with `%` prefix from the 14-digit GeoAPI tracking number
- Add `it4emServiceCodeForBaselinker()` on `Dpd`, reusing `resolvedAlzaCarrierMethod()` shared with `buildAlzaTradeServices` (327/329/337/101)
- Map destination country to DPD barcode digits (203 CZ, 703 SK)

## Test plan
- [ ] `Dpd::fullBarcodeForBaselinker($alzaOrder, '13885041520661')` returns `%001930013885041520661327203` for DPD-DPD + PSČ 19300
- [ ] Service 337 for DPD-DPDALZABOX, 101 for DPD-Supplier


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tracking extraction for 28-digit barcodes and new barcode assembly logic; incorrect offsets or service/country digits would break Baselinker sync and scanning.
> 
> **Overview**
> Adds **Baselinker/Alza package sync** support by building the full DPD Code 128 barcode (`%` + 7-digit postcode + 14-digit tracking + 3-digit IT4EM service + 3-digit country) from GeoAPI’s 14-digit `parcelNumbers.main`, so synced numbers match printed labels.
> 
> Introduces `fullBarcodeForBaselinker()` and `it4emServiceCodeForBaselinker()` with IT4EM codes **327/329/337/101** aligned to Alza `carrier_id`, pickup/COD, and destination country (**203** CZ, **703** SK). Alza carrier resolution is centralized in `resolvedAlzaCarrierMethod()` / `alzaIt4emServiceCode()` and reused by `buildAlzaTradeServices()`.
> 
> **Fixes barcode parsing** in `DpdParcelIdentifier`: 27- and 28-digit payloads now use different offsets when extracting the 14-digit tracking number (previously both used the same slice).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f260d9f088ea0f5248c66275274945af7f2807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->